### PR TITLE
feat: allow response to be text

### DIFF
--- a/wasm-fiddle-server/server.js
+++ b/wasm-fiddle-server/server.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { existsSync } from "fs";
+import { existsSync, fstat, readFile } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { 
@@ -40,7 +40,27 @@ app.post("/compile", async (req, res) => {
   let test = checkExistsWithTimeout(__dirname + `/files/${fn}.wasm`, 7000);
   test.then(() => {
     console.log("Successfully compiled");
-    res.sendFile(__dirname + `/files/${fn}.wasm`);
+
+    
+    // send as file or as text
+    if(req.body.sendAsFile){
+      res.sendFile(__dirname + `/files/${fn}.wasm`);
+    } else {
+      readFile(__dirname + `/files/${fn}.wasm`, function (err, data){
+        if (!err){
+          console.log("Sent as text");
+          res.set('Content-Type', 'text/plain');
+          res.status(200);
+          res.send(data);
+        }
+        else {
+          res.set('Content-Type', 'text/plain');
+          res.status(500);
+          res.send("Could not send as text");
+        }
+      });
+    }
+    
   })
     .catch((err) => {
       console.error(`Could not find file - ${err.message}`);


### PR DESCRIPTION
by default, "/compile" sends as text. Must include "sendAsFile" in the body to receive a file as a response.